### PR TITLE
Added Wood, Auto PaperMakers, Research Team, Employees, Research, Thinking and Small UI Redesign

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import logo from './logo.svg';
 import './App.scss';
 import { connect } from 'react-redux';
 import { withRouter} from 'react-router-dom';
-import { updPaper, updAutoClickers, updMoney, updSalePrice, updStock } from './store';
+import { updPaper, updAutoClickers, updMoney, updSalePrice, updStock, updWood } from './store';
 
 class App extends Component {
   constructor(props) {
@@ -15,7 +15,8 @@ class App extends Component {
       autoClickers: this.props.autoClickers || 0,
       money: this.props.money || 0,
       salePrice: this.props.salePrice || 0.25,
-      interest: 0.08/this.props.salePrice
+      interest: 0.08/this.props.salePrice,
+      wood: this.props.wood || 1000
     }
   }
 
@@ -25,7 +26,7 @@ class App extends Component {
   */
   componentDidMount() {
     if (this.state.autoClickers > 0) {
-      window.setInterval(() => this.clickerAdd(), 1000 / this.state.autoClickers)
+      window.setInterval(() => this.click(), 1000 / this.state.autoClickers)
     }
     this.timedEvents()
   }
@@ -46,11 +47,15 @@ class App extends Component {
   }
 
   // Add paper to the paper total
-  clickerAdd() {
-    this.setState({paper: this.state.paper + 1, stock: this.state.stock + 1}, () => {
-      this.props.updatePaper(this.state.paper)
-      this.props.updateStock(this.state.stock)
-    })
+  click() {
+    if (this.state.wood > 0) {
+      var randomWood = Math.random()
+      this.setState({paper: this.state.paper + 1, stock: this.state.stock + 1, wood: this.state.wood - randomWood > 0 ? this.state.wood - randomWood : 0}, () => {
+        this.props.updatePaper(this.state.paper)
+        this.props.updateStock(this.state.stock)
+        this.props.updateWood(this.state.wood)
+      })
+    }
   }
 
   // Add a new auto clicker
@@ -59,7 +64,16 @@ class App extends Component {
       this.props.updateAutoClickers(this.state.autoClickers)
       this.props.updateMoney(this.state.money)
     })
-    window.setInterval(() => this.clickerAdd(), 1000)
+    window.setInterval(() => this.click(), 1000)
+  }
+
+  // Add more wood
+  chopWood() {
+    this.setState({wood: this.state.wood + 800, money: this.state.money - 50}, () => {
+      this.props.updateWood(this.state.wood)
+      this.props.updateMoney(this.state.money)
+    })
+    window.setInterval(() => this.click(), 1000)
   }
 
   // Sell paper
@@ -93,7 +107,7 @@ class App extends Component {
 
   renderClickButton() {
     return (
-      <div className='clicker' onClick={() => this.clickerAdd()}>
+      <div className='clicker' onClick={() => this.click()}>
         Make Paper
       </div>
     )
@@ -103,6 +117,14 @@ class App extends Component {
     return (
       <div className={this.state.money > 25 ? 'clicker' : 'clicker-disabled'} onClick={this.state.money > 25 ? () => this.autoClickerAdd() : ''}>
         Buy Auto Paper Maker (£25)
+      </div>
+    )
+  }
+
+  renderChopWoodButton() {
+    return (
+      <div className={this.state.money > 50 ? 'clicker' : 'clicker-disabled'} onClick={this.state.money > 50 ? () => this.chopWood() : ''}>
+        Chop Down More Wood (£50)
       </div>
     )
   }
@@ -141,6 +163,9 @@ class App extends Component {
         <p className='clicks'>
           Paper Per Second: {this.state.autoClickers}
         </p>
+        <p className='clicks'> 
+          Remaining Wood: {this.state.wood.toFixed(2)}
+        </p>
       </div>      
     )
   }
@@ -151,6 +176,7 @@ class App extends Component {
         <div className="playSide">
           {this.renderClickButton()}
           {this.renderSaleButtons()}
+          {this.state.paper > 500 ? this.renderChopWoodButton() : ''}
           {this.state.paper > 100 ? this.renderAutoClickButton() : ''}
         </div>
         <div className="statSide">
@@ -183,6 +209,9 @@ const mapDispatchToProps = (dispatch) => {
     },
     updateStock: (stock) => {
       dispatch(updStock(stock))
+    },
+    updateWood: (wood) => {
+      dispatch(updWood(wood))
     }
   }};
 

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,6 @@ class App extends Component {
   *   Then start the infinite selling loop
   */
   componentDidMount() {
-    console.log(this.props.wood)
     if (this.state.autoClickers > 0) {
       window.setInterval(() => this.click(), 1000 / this.state.autoClickers)
     }
@@ -113,15 +112,17 @@ class App extends Component {
   }
 
   hireEmployees() {
-    this.setState({employees: this.state.employees + 1}, () => {
+    this.setState({employees: this.state.employees + 1, money: this.state.money - 500}, () => {
       this.props.updateEmployees(this.state.employees)
+      this.props.updateMoney(this.state.money)
       this.updateThinker()
     })
   }
 
   trainEmployees() {
-    this.setState({thinkSpeed: this.state.thinkSpeed + 1}, () => {
+    this.setState({thinkSpeed: this.state.thinkSpeed + 1, money: this.state.money - 1000}, () => {
       this.props.updateThinkSpeed(this.state.thinkSpeed)
+      this.props.updateMoney(this.state.money)
       this.updateThinker()
     })
   }
@@ -169,8 +170,9 @@ class App extends Component {
   renderResearchTeamButton() {
     return (
       <div className={this.state.money > 1000 ? 'clicker' : 'clicker disabled'} onClick={this.state.money > 1000 ? () => {
-        this.setState({stage: 2}, () => {
+        this.setState({stage: 2, money: this.state.money - 1000}, () => {
           this.props.updateStage(this.state.stage)
+          this.props.updateMoney(this.state.money)
         })
       } : ''}>
         Buy Research Team (£1000)

--- a/src/App.js
+++ b/src/App.js
@@ -132,11 +132,11 @@ class App extends Component {
   renderSaleButtons() {
     return (
       <div className='saleButtons'>
-        <div className='clicker' onClick={() => this.increaseSalePrice()}>
-          Increase Price
-        </div>
         <div className='clicker' onClick={() => this.decreaseSalePrice()}>
           Decrease Price
+        </div>
+        <div className='clicker' onClick={() => this.increaseSalePrice()}>
+          Increase Price
         </div>
       </div>
     )
@@ -149,18 +149,6 @@ class App extends Component {
           Total Paper: {this.state.paper}
         </p>
         <p className='clicks'>
-          Stock: {this.state.stock}
-        </p>
-        <p className='clicks'>
-          Money: £{this.state.money.toFixed(2)}
-        </p>
-        <p className='clicks'>
-          Selling Price: £{this.state.salePrice.toFixed(2)}
-        </p>
-        <p className='clicks'>
-          Public Interest: {(this.state.interest*100).toFixed(2)}%
-        </p>
-        <p className='clicks'>
           Paper Per Second: {this.state.autoClickers}
         </p>
         <p className='clicks'> 
@@ -170,17 +158,42 @@ class App extends Component {
     )
   }
 
+  renderFinancesSection() {
+    return (
+      <div>
+        <p className='clicks'>
+        Stock: {this.state.stock}
+        </p>
+        <p className='clicks'>
+          Money: £{this.state.money.toFixed(2)}
+        </p>
+        <p className='clicks'>
+          Public Interest: {(this.state.interest*100).toFixed(2)}%
+        </p>
+        <p className='clicks'>
+          Selling Price: £{this.state.salePrice.toFixed(2)}
+        </p>
+        {this.renderSaleButtons()}
+        
+      </div>
+      
+    )
+  }
+
   render() {
     return (
       <div className="app">
-        <div className="playSide">
-          {this.renderClickButton()}
-          {this.renderSaleButtons()}
-          {this.state.paper > 500 ? this.renderChopWoodButton() : ''}
-          {this.state.paper > 100 ? this.renderAutoClickButton() : ''}
+        <div className="finances">
+          {this.renderFinancesSection()}
         </div>
-        <div className="statSide">
+        <div className="play">
           {this.renderPaper()}
+          {this.renderClickButton()}
+          {this.state.paper > 100 ? this.renderAutoClickButton() : ''}
+          {this.state.paper > 500 ? this.renderChopWoodButton() : ''}
+        </div>
+        <div className="researchTeam">
+
         </div>
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -55,8 +55,9 @@ class App extends Component {
 
   // Add a new auto clicker
   autoClickerAdd() {
-    this.setState({autoClickers: this.state.autoClickers + 1}, () => {
+    this.setState({autoClickers: this.state.autoClickers + 1, money: this.state.money - 25}, () => {
       this.props.updateAutoClickers(this.state.autoClickers)
+      this.props.updateMoney(this.state.money)
     })
     window.setInterval(() => this.clickerAdd(), 1000)
   }
@@ -100,7 +101,7 @@ class App extends Component {
 
   renderAutoClickButton() {
     return (
-      <div className='clicker' onClick={() => this.autoClickerAdd()}>
+      <div className={this.state.money > 25 ? 'clicker' : 'clicker-disabled'} onClick={this.state.money > 25 ? () => this.autoClickerAdd() : ''}>
         Buy Auto Paper Maker
       </div>
     )
@@ -149,8 +150,8 @@ class App extends Component {
       <div className="app">
         <div className="playSide">
           {this.renderClickButton()}
-          {/*this.renderAutoClickButton()*/}
           {this.renderSaleButtons()}
+          {this.state.paper > 100 ? this.renderAutoClickButton() : ''}
         </div>
         <div className="statSide">
           {this.renderPaper()}

--- a/src/App.js
+++ b/src/App.js
@@ -102,7 +102,7 @@ class App extends Component {
   renderAutoClickButton() {
     return (
       <div className={this.state.money > 25 ? 'clicker' : 'clicker-disabled'} onClick={this.state.money > 25 ? () => this.autoClickerAdd() : ''}>
-        Buy Auto Paper Maker
+        Buy Auto Paper Maker (£25)
       </div>
     )
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -47,6 +47,22 @@ $gradient-5: #F9F871;
   -ms-user-select: none;
 }
 
+.clicker-disabled {
+  margin: 0.5rem;
+  text-align: center;
+  background-color: $gradient-2;
+  color: white;
+  padding: 2rem;
+  border-radius: 5%;
+  user-select: none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+
+  opacity: 50%;
+}
+
 .saleButtons {
   margin: 1rem;
   display: flex;

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,31 +13,48 @@ $gradient-5: #F9F871;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
   color: white;
+  font-size: 1.35rem;
 }
 
-.playSide {
+.play {
   display: flex;
   flex-direction: column;
   margin: 2rem;
   padding: 1rem;
+  border-style: solid;
+  border-color: $gradient-3;
+  border-radius: 2.5%;
+  text-align: center;
 }
 
-.statSide {
+.finances {
   display: flex;
   flex-direction: column;
   padding: 1rem;
   margin: 2rem;
-  border-radius: 10%;
+  border-radius: 2.5%;
+  border-style: solid;
+  border-color: $gradient-3;
+  border-radius: 2.5%;
+  text-align: center
+}
+
+.researchTeam {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  margin: 2rem;
+  text-align: center
 }
 
 .clicker {
   margin: 0.5rem;
+  
   text-align: center;
   background-color: $gradient-2;
   color: white;
-  padding: 2rem;
+  padding: 1rem;
   border-radius: 5%;
   cursor: pointer;
   user-select: none;

--- a/src/App.scss
+++ b/src/App.scss
@@ -12,15 +12,23 @@ $gradient-5: #F9F871;
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: space-evenly;
   color: white;
   font-size: 1.35rem;
+}
+
+.hidden {
+  visibility: hidden;
+}
+
+.disabled {
+  cursor: default;
+  opacity: 50%;
 }
 
 .play {
   display: flex;
   flex-direction: column;
-  margin: 2rem;
   padding: 1rem;
   border-style: solid;
   border-color: $gradient-3;
@@ -32,7 +40,6 @@ $gradient-5: #F9F871;
   display: flex;
   flex-direction: column;
   padding: 1rem;
-  margin: 2rem;
   border-radius: 2.5%;
   border-style: solid;
   border-color: $gradient-3;
@@ -44,13 +51,15 @@ $gradient-5: #F9F871;
   display: flex;
   flex-direction: column;
   padding: 1rem;
-  margin: 2rem;
-  text-align: center
+  text-align: center;
+  border-radius: 2.5%;
+  border-style: solid;
+  border-color: $gradient-3;
+  border-radius: 2.5%;
 }
 
 .clicker {
   margin: 0.5rem;
-  
   text-align: center;
   background-color: $gradient-2;
   color: white;
@@ -64,28 +73,15 @@ $gradient-5: #F9F871;
   -ms-user-select: none;
 }
 
-.clicker-disabled {
-  margin: 0.5rem;
-  text-align: center;
-  background-color: $gradient-2;
-  color: white;
-  padding: 2rem;
-  border-radius: 5%;
-  user-select: none;
-  -moz-user-select: none;
-  -khtml-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-
-  opacity: 50%;
-}
-
 .saleButtons {
   margin: 1rem;
   display: flex;
-  
 }
 
 .clicker:hover {
   background-color: $gradient-3;
+}
+
+.disabled:hover {
+  background-color: $gradient-2;
 }

--- a/src/store.js
+++ b/src/store.js
@@ -51,6 +51,12 @@ const actions = (state, action) => {
         ...state,
         stock: action.payload
       }
+      
+    case "updateWood":
+      return {
+        ...state,
+        wood: action.payload
+      }
 
     default: {
       return state;
@@ -96,6 +102,13 @@ export const updStock = (stock) => {
   return {
     type: "updateStock",
     payload: stock
+  }
+}
+
+export const updWood = (wood) => {
+  return {
+    type: "updateWood",
+    payload: wood
   }
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -58,6 +58,30 @@ const actions = (state, action) => {
         wood: action.payload
       }
 
+    case "updateStage":
+      return {
+        ...state,
+        stage: action.payload
+      }
+    
+    case "updateEmployees":
+      return {
+        ...state,
+        employees: action.payload
+      }
+    
+    case "updateResearch":
+      return {
+        ...state,
+        research: action.payload
+      }
+
+    case "updateThinkSpeed":
+      return {
+        ...state,
+        thinkSpeed: action.payload
+      }
+
     default: {
       return state;
     }
@@ -109,6 +133,34 @@ export const updWood = (wood) => {
   return {
     type: "updateWood",
     payload: wood
+  }
+}
+
+export const updStage = (stage) => {
+  return {
+    type: "updateStage",
+    payload: stage
+  }
+}
+
+export const updEmployees = (employees) => {
+  return {
+    type: "updateEmployees",
+    payload: employees
+  }
+}
+
+export const updResearch = (research) => {
+  return {
+    type: "updateResearch",
+    payload: research
+  }
+}
+
+export const updThinkSpeed = (thinkSpeed) => {
+  return {
+    type: "updateThinkSpeed",
+    payload: thinkSpeed
   }
 }
 


### PR DESCRIPTION
This PR adds functionality for the following:

- #1 Wood is now an important component of the game to be able to produce paper, to get more wood requires £50. Every paper costs a randomiser between 0 and 1 wood.
- #11 Auto PaperMakers can be purchased for £25, they will add an additional paper per second to the game.
- #9 Research team can be purchased for £1000 after the game has created their first 2000 paper. This will initiate Stage 2 of the game, opening up the the research team tab.  The research team tab includes the users' Employees, Think Speed and total research acquired. Users can hire more employees for £500 which increases their employees, or Train their employees for £1000 which improves their Think Speed. Research is acquired on a calculation of employees and think speed. In the future, projects and items can be improved by purchasing things with Research 
- The UI Design was necessary as more and more items get added to the system. I've split up the game into three tabs spread evenly across the screen. The left tab includes everything finance-wise such as selling price, public interest and money. This tab won't appear until the user has created at least 10 paper. The middle tab holds paper-important information such as paper per second, total paper and remaining wood, as well as the buttons for making paper and other purchases. The research team tab will appear on the right when appropriate.