### PR TITLE
Fixed opacity values for game buttons

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -23,7 +23,7 @@ $gradient-5: #F9F871;
 
 .disabled {
   cursor: default;
-  opacity: 50%;
+  opacity: 0.5;
 }
 
 .play {


### PR DESCRIPTION
All opacity values have been changed from percentage to decimal values. 


https://github.com/3eak/paper-clicker/issues/22