### PR TITLE
Added new research project which scales to improve paper makers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
-import logo from './logo.svg';
 import './App.scss';
 import { connect } from 'react-redux';
 import { withRouter} from 'react-router-dom';
-import { updPaper, updAutoClickers, updMoney, updSalePrice, updStock, updWood, updStage, updEmployees, updResearch, updThinkSpeed } from './store';
+import { updPaper, updAutoClickers, updMoney, updSalePrice, updStock, updWood, updStage, updEmployees, updResearch, updThinkSpeed, updPaperMakerLevel } from './store';
 
 class App extends Component {
   constructor(props) {
@@ -20,7 +19,8 @@ class App extends Component {
       stage: this.props.stage || 1,
       employees: this.props.employees || 1,
       research: this.props.research || 0,
-      thinkSpeed: this.props.thinkSpeed || 1
+      thinkSpeed: this.props.thinkSpeed || 1,
+      paperMakerLevel: this.props.paperMakerLevel || 1
     }
   }
 
@@ -30,7 +30,8 @@ class App extends Component {
   */
   componentDidMount() {
     if (this.state.autoClickers > 0) {
-      window.setInterval(() => this.click(), 1000 / this.state.autoClickers)
+      // Simulate level of auto clickers from previous save
+      window.setInterval(() => this.click(), (1000 / this.state.paperMakerLevel) / this.state.autoClickers)
     }
     if (this.state.stage > 1) {
       this.updateThinker()
@@ -86,7 +87,8 @@ class App extends Component {
       this.props.updateAutoClickers(this.state.autoClickers)
       this.props.updateMoney(this.state.money)
     })
-    window.setInterval(() => this.click(), 1000)
+    // After adding new clicker, add manual interval to the timer
+    window.setInterval(() => this.click(), 1000 / this.state.paperMakerLevel)
   }
 
   // Add more wood
@@ -143,6 +145,13 @@ class App extends Component {
     }
   }
 
+  upgradePaperMaker() {
+    this.setState({research: this.state.research - (Math.pow(this.state.paperMakerLevel,2) * 500), paperMakerLevel: this.state.paperMakerLevel + 1}, () => {
+      this.props.updatePaperMakerLevel(this.state.paperMakerLevel)
+      this.props.updateResearch(this.state.research)
+    })
+  }
+
   renderClickButton() {
     return (
       <div className='clicker' onClick={() => this.click()}>
@@ -176,6 +185,14 @@ class App extends Component {
         })
       } : ''}>
         Buy Research Team (£1000)
+      </div>
+    )
+  }
+
+  renderUpgradePaperMaker() {
+    return (
+      <div className={this.state.research > Math.pow(this.state.paperMakerLevel,2) * 500 ? 'clicker' : 'clicker disabled'} onClick={this.state.research > Math.pow(this.state.paperMakerLevel,2) * 500 ? () => this.upgradePaperMaker() : ''}>
+        Upgrade Paper Makers ({Math.pow(this.state.paperMakerLevel,2) * 500} Research)
       </div>
     )
   }
@@ -255,6 +272,7 @@ class App extends Component {
         <p className='clicks'>
           Think Speed: {this.state.thinkSpeed}
         </p>
+        {this.renderUpgradePaperMaker()}
       </div>
     )
   }
@@ -266,9 +284,8 @@ class App extends Component {
           {this.renderFinancesSection()}
         </div>
         <div className="play">
-          
           {this.renderPlaySection()}
-          </div>
+        </div>
         <div className={this.state.stage > 1 ? "researchTeam" : "researchTeam hidden"}>
           {this.renderResearchSection()}
         </div>
@@ -314,6 +331,9 @@ const mapDispatchToProps = (dispatch) => {
     },
     updateThinkSpeed: (thinkSpeed) => {
       dispatch(updThinkSpeed(thinkSpeed))
+    },
+    updatePaperMakerLevel: (paperMakerLevel) => {
+      dispatch(updPaperMakerLevel(paperMakerLevel))
     }
   }};
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import logger from 'redux-logger';
 import { persistStore, persistReducer } from 'redux-persist'
 import storage from 'redux-persist/lib/storage';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
@@ -82,6 +81,12 @@ const actions = (state, action) => {
         thinkSpeed: action.payload
       }
 
+    case "updatePaperMakerLevel":
+      return {
+        ...state,
+        paperMakerLevel: action.payload
+      }
+
     default: {
       return state;
     }
@@ -161,6 +166,13 @@ export const updThinkSpeed = (thinkSpeed) => {
   return {
     type: "updateThinkSpeed",
     payload: thinkSpeed
+  }
+}
+
+export const updPaperMakerLevel = (paperMakerLevel) => {
+  return {
+    type: "updatePaperMakerLevel",
+    payload: paperMakerLevel
   }
 }
 


### PR DESCRIPTION
Addresses new feature in #27 

Added research project which improves the paper makers to enable the user to make paper quicker. 

It scales like so:

PaperMakerLevel^2 * 500

Thus the prices will be like so (in Research costs)
500
2000
4500
8000
12500
18000
24500
32000
40500

The improvements that these make are a little more subtle and could do with an improvement in my opinion:

It simply will instead of making the AutoClicker click once a second it will do it like so:

Second / PaperMakerLevel

Level | How often it will click:
1 = 1 Second
2 = 0.5 Second
3 = 0.33 Second
4 = 0.25 Second
5 = 0.2 Second
6 = 0.167 Second
7 = 0.143 Second
8 = 0.125 Second